### PR TITLE
Move authproc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,29 @@ required in your `composer.json` file. The `composer-module-installer` package
 will discover this module and copy it into the `modules` folder within 
 `simplesamlphp`.
 
-You will then need to set filter parameters in your config.php file.
+You will then need to set filter parameters in your config. We recommend adding 
+them to the `'authproc'` array in your `metadata/saml20-idp-hosted.php` file, 
+but you are also able to put them in the `'authproc.idp'` array in your 
+`config/config.php` file.
 
-Example:
+Example (in `metadata/saml20-idp-hosted.php`):
 
-    10 => [
-        // Required:
-        'class' => 'expirychecker:ExpiryDate',
-        'accountNameAttr' => 'cn',
-        'expiryDateAttr' => 'schacExpiryDate',
-        'changePwdUrl' => 'https://idm.example.com/pwdmgr/',
+    'authproc' => [
+        10 => [
+            // Required:
+            'class' => 'expirychecker:ExpiryDate',
+            'accountNameAttr' => 'cn',
+            'expiryDateAttr' => 'schacExpiryDate',
+            'changePwdUrl' => 'https://idm.example.com/pwdmgr/',
+
+            // Optional:
+            'warnDaysBefore' => 14,
+            'originalUrlParam' => 'originalurl',
+            'dateFormat' => 'm.d.Y', // Use PHP's date syntax.
+            'loggerClass' => '\\Sil\\Psr3Adapters\\Psr3SamlLogger',
+        ],
         
-        // Optional:
-        'warnDaysBefore' => 14,
-        'originalUrlParam' => 'originalurl',
-        'dateFormat' => 'm.d.Y', // Use PHP's date syntax.
-        'loggerClass' => '\\Sil\\Psr3Adapters\\Psr3SamlLogger',
+        // ...
     ],
 
 The `accountNameAttr` parameter represents the SAML attribute name which has 

--- a/development/idp-local/config/config.php
+++ b/development/idp-local/config/config.php
@@ -4,7 +4,6 @@
  *
  */
 use Sil\PhpEnv\Env;
-use Sil\Psr3Adapters\Psr3SamlLogger;
 
 /*
  * Get config settings from ENV vars or set defaults
@@ -495,16 +494,6 @@ $config = [
      * Both Shibboleth and SAML 2.0
      */
     'authproc.idp' => [
-        
-        10 => [
-            'class' => 'expirychecker:ExpiryDate',
-            'accountNameAttr' => 'cn',
-            'expiryDateAttr' => 'schacExpiryDate',
-            'changePwdUrl' => Env::get('CHANGE_PWD_URL'),
-            'warnDaysBefore' => 14,
-            'dateFormat' => 'Y-m-d',
-            'loggerClass' => Psr3SamlLogger::class,
-        ],
         
         /* Enable the authproc filter below to add URN Prefixces to all attributes
          10 => array(

--- a/development/idp-local/metadata/saml20-idp-hosted.php
+++ b/development/idp-local/metadata/saml20-idp-hosted.php
@@ -1,10 +1,13 @@
 <?php
+
+use Sil\PhpEnv\Env;
+use Sil\Psr3Adapters\Psr3SamlLogger;
+
 /**
  * SAML 2.0 IdP configuration for SimpleSAMLphp.
  *
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
  */
-
 $metadata['http://ssp-hub-idp.local:8085'] = [
 	/*
 	 * The hostname of the server (VHOST) that will use this SAML entity.
@@ -22,4 +25,16 @@ $metadata['http://ssp-hub-idp.local:8085'] = [
 	 * 'config/authsources.php'.
 	 */
 	'auth' => 'example-userpass',
+    
+    'authproc' => [
+        10 => [
+            'class' => 'expirychecker:ExpiryDate',
+            'accountNameAttr' => 'cn',
+            'expiryDateAttr' => 'schacExpiryDate',
+            'changePwdUrl' => Env::get('CHANGE_PWD_URL'),
+            'warnDaysBefore' => 14,
+            'dateFormat' => 'Y-m-d',
+            'loggerClass' => Psr3SamlLogger::class,
+        ],
+    ],
 ];


### PR DESCRIPTION
Rather than having this authproc's config in the main `config/config.php` file, it seems better to demonstrate how to specify it in the `metadata/saml20-idp-hosted.php` file since for ssp-base we won't want it configured by default.