### PR TITLE
Fix redirect for expired too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ or that it has already expired.
 
 **NOTE:** This module does *not* prevent the user from logging in. It merely 
 shows a warning page (if their password is about to expire), with the option to 
-change their password now or later, or it tells the user that they password has 
+change their password now or later, or it tells the user that their password has
 already expired, with the only option being to go change their password now. 
 Both of these pages will be bypassed (for varying lengths of time) if the user 
 has recently seen one of those two pages, in order to allow the user to get to 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 A simpleSAMLphp module for warning users that their password will expire soon 
 or that it has already expired.
 
+**NOTE:** This module does *not* prevent the user from logging in. It merely 
+shows a warning page (if their password is about to expire), with the option to 
+change their password now or later, or it tells the user that they password has 
+already expired, with the only option being to go change their password now. 
+Both of these pages will be bypassed (for varying lengths of time) if the user 
+has recently seen one of those two pages, in order to allow the user to get to 
+the change-password website (assuming it is also behind this IdP). If the user 
+should not be allowed to log in at all, the simpleSAMLphp Auth. Source should 
+consider the credentials provided by the user to be invalid.
+
 The expirychecker module is implemented as an Authentication Processing Filter, 
 or AuthProc. That means it can be configured in the global config.php file or 
 the SP remote or IdP hosted metadata.

--- a/www/about2expire.php
+++ b/www/about2expire.php
@@ -1,5 +1,7 @@
 <?php
 
+use sspmod_expirychecker_Auth_Process_ExpiryDate as ExpiryDate;
+
 $stateId = filter_input(INPUT_GET, 'StateId') ?? null;
 if (empty($stateId)) {
     throw new SimpleSAML_Error_BadRequest('Missing required StateId query parameter.');
@@ -7,13 +9,9 @@ if (empty($stateId)) {
 
 $state = SimpleSAML_Auth_State::loadState($stateId, 'expirychecker:about2expire');
 
-$session = SimpleSAML_Session::getSession();
-$changePwdSession = 'sent_to_change_password';
-$hasClickedChangePassword = $session->getData('expirychecker', $changePwdSession);
-
-if ($hasClickedChangePassword) {
-    SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
-}
+/* Skip the splash pages for awhile, both to let the user get to the
+ * change-password website and to avoid annoying them with constant warnings. */
+ExpiryDate::skipSplashPagesFor(14400); // 14400 seconds = 4 hours
 
 if (array_key_exists('continue', $_REQUEST)) {
     
@@ -41,10 +39,6 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         }
     }
     
-    // set a value to tell us they've probably changed
-    // their password, in order to allow password to get propagated
-    $session->setData('expirychecker', $changePwdSession, true, (60*10));
-    $session->save();
     SimpleSAML_Utilities::redirect($changePwdUrl, array());
 }
 

--- a/www/expired.php
+++ b/www/expired.php
@@ -1,5 +1,7 @@
 <?php
 
+use sspmod_expirychecker_Auth_Process_ExpiryDate as ExpiryDate;
+
 $stateId = filter_input(INPUT_GET, 'StateId') ?? null;
 if (empty($stateId)) {
     throw new SimpleSAML_Error_BadRequest('Missing required StateId query parameter.');

--- a/www/expired.php
+++ b/www/expired.php
@@ -7,14 +7,11 @@ if (empty($stateId)) {
 
 $state = SimpleSAML_Auth_State::loadState($stateId, 'expirychecker:expired');
 
-/* See if they're on their way to the change password page, and if so, let them
- * straight through.   */
-$chgPwdUrlQueryParam = "&RelayState=" .  urlencode($state['changePwdUrl']);
-if (strpos($stateId, $chgPwdUrlQueryParam) !== false) {
-    SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
-}
-
 if (array_key_exists('changepwd', $_REQUEST)) {
+    
+    /* Now that they've clicked change-password, skip the splash pages very
+     * briefly, to let the user get to the change-password website.  */
+    ExpiryDate::skipSplashPagesFor(60); // 60 seconds = 1 minute
     
     // The user has pressed the change-password button.
     $changePwdUrl = $state['changePwdUrl'];
@@ -33,14 +30,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
             $changePwdUrl .= '?returnTo=' . $returnTo;
         }
     }
-
-    $changePwdSession = 'sent_to_change_password';
-    $session = SimpleSAML_Session::getSession();
     
-    // set a value to tell us they've probably changed
-    // their password, in order to allow password to get propagated
-    $session->setData('expirychecker', $changePwdSession, 1, (60*10));
-    $session->save();
     SimpleSAML_Utilities::redirect($changePwdUrl, array());
 }
 


### PR DESCRIPTION
This fixes the problem for the "expired" page, too, and consolidates the code to reduce duplication.

I feel like the 60 seconds may be longer than we really want, since it only has to be long enough for the user to log in to the password manager website, but it gets the job done. We could probably shorten it to 10 or 15 seconds with no adverse effects if any of you think it necessary.