### PR TITLE
Use namespaced ssp classes

### DIFF
--- a/development/idp-local/www_saml2_idp_SSOService.php
+++ b/development/idp-local/www_saml2_idp_SSOService.php
@@ -10,7 +10,7 @@
 
 require_once('../../_include.php');
 
-SimpleSAML_Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
+SimpleSAML\Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
 
 $metadata = SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler();
 $idpEntityId = $metadata->getMetaDataCurrentEntityID('saml20-idp-hosted');

--- a/lib/Auth/Process/ExpiryDate.php
+++ b/lib/Auth/Process/ExpiryDate.php
@@ -18,9 +18,9 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
     
     private $warnDaysBefore = 14;
     private $originalUrlParam = 'originalurl';
-    private $passwordChangeUrl = NULL;
-    private $accountNameAttr = NULL;
-    private $expiryDateAttr = NULL;
+    private $passwordChangeUrl = null;
+    private $accountNameAttr = null;
+    private $expiryDateAttr = null;
     private $dateFormat = 'Y-m-d';
     
     /** @var LoggerInterface */
@@ -72,7 +72,6 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
     protected function loadValuesFromConfig($config, $attributeRules)
     {
         foreach ($attributeRules as $attribute => $rules) {
-            
             if (array_key_exists($attribute, $config)) {
                 $this->$attribute = $config[$attribute];
             }
@@ -179,7 +178,7 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
     {
         $loggerClass = $config['loggerClass'] ?? Psr3SamlLogger::class;
         $this->logger = new $loggerClass();
-        if ( ! $this->logger instanceof LoggerInterface) {
+        if (! $this->logger instanceof LoggerInterface) {
             throw new Exception(sprintf(
                 'The specified loggerClass (%s) does not implement '
                 . '\\Psr\\Log\\LoggerInterface.',
@@ -197,7 +196,7 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
     public function isDateInPast(int $timestamp)
     {
         return ($timestamp < time());
-    }    
+    }
     
     /**
      * Check whether the user's password has expired.
@@ -246,22 +245,28 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
         /* Save state and redirect. */
         $state['expiresAtTimestamp'] = $expiryTimestamp;
         $state['accountName'] = $accountName;
-        $id = SimpleSAML_Auth_State::saveState($state,
-            'expirychecker:redirected_to_password_change_url');
+        $id = SimpleSAML_Auth_State::saveState(
+            $state,
+            'expirychecker:redirected_to_password_change_url'
+        );
         $ignoreMinutes = 60;
 
-        $session = SimpleSAML_Session::getInstance();     
-        $idpExpirySession = $session->getData($sessionType,$change_pwd_session);
+        $session = SimpleSAML_Session::getInstance();
+        $idpExpirySession = $session->getData($sessionType, $change_pwd_session);
         
         // If the session shows that the User already passed this way,
         //  don't redirect to change password page
-        if ($idpExpirySession !== Null) {
+        if ($idpExpirySession !== null) {
             SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
         } else {
             // Otherwise, set a value to tell us they've probably changed
             // their password, in order to allow password to get propagated
-            $session->setData($sessionType, $change_pwd_session, 
-                              1, (60 * $ignoreMinutes));
+            $session->setData(
+                $sessionType,
+                $change_pwd_session,
+                1,
+                (60 * $ignoreMinutes)
+            );
             $session->saveSession();
         }
         
@@ -271,13 +276,13 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
          * original destination url as a parameter.  */
         if (array_key_exists('saml:RelayState', $state)) {
             $relayState = $state['saml:RelayState'];
-            if (strpos($relayState, $passwordChangeUrl) !== false) {                
+            if (strpos($relayState, $passwordChangeUrl) !== false) {
                 SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
             } else {
                 $returnTo = sspmod_expirychecker_Utilities::getUrlFromRelayState(
                     $relayState
                 );
-                if ( ! empty($returnTo)) {                                 
+                if (! empty($returnTo)) {
                     $passwordChangeUrl .= '?returnTo=' . $returnTo;
                 }
             }
@@ -363,9 +368,9 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
         $daysLeft = $this->getDaysLeftBeforeExpiry($expiryTimestamp);
         $state['daysLeft'] = $daysLeft;
         
-        if (isset($state['isPassive']) && $state['isPassive'] === TRUE) {
-          /* We have a passive request. Skip the warning. */
-          return;
+        if (isset($state['isPassive']) && $state['isPassive'] === true) {
+            /* We have a passive request. Skip the warning. */
+            return;
         }
         
         $this->logger->warning(sprintf(

--- a/lib/Auth/Process/ExpiryDate.php
+++ b/lib/Auth/Process/ExpiryDate.php
@@ -344,7 +344,7 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
         $state['originalUrlParam'] = $this->originalUrlParam;
         
         $id = SimpleSAML_Auth_State::saveState($state, 'expirychecker:expired');
-        $url = SimpleSAML_Module::getModuleURL('expirychecker/expired.php');
+        $url = SimpleSAML\Module::getModuleURL('expirychecker/expired.php');
         
         SimpleSAML_Utilities::redirect($url, array('StateId' => $id));
     }
@@ -380,7 +380,7 @@ class sspmod_expirychecker_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Proce
         $state['originalUrlParam'] = $this->originalUrlParam;
         
         $id = SimpleSAML_Auth_State::saveState($state, 'expirychecker:about2expire');
-        $url = SimpleSAML_Module::getModuleURL('expirychecker/about2expire.php');
+        $url = SimpleSAML\Module::getModuleURL('expirychecker/about2expire.php');
         
         SimpleSAML_Utilities::redirect($url, array('StateId' => $id));
     }

--- a/www/about2expire.php
+++ b/www/about2expire.php
@@ -53,4 +53,4 @@ $t->data['expiresAtTimestamp'] = $state['expiresAtTimestamp'];
 $t->data['accountName'] = $state['accountName'];
 $t->show();
 
-SimpleSAML_Logger::info('expirychecker - User has been warned that their password will expire soon.');
+SimpleSAML\Logger::info('expirychecker - User has been warned that their password will expire soon.');

--- a/www/about2expire.php
+++ b/www/about2expire.php
@@ -45,7 +45,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
 $globalConfig = SimpleSAML_Configuration::getInstance();
 
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'expirychecker:about2expire.php');
-$t->data['formTarget'] = SimpleSAML_Module::getModuleURL('expirychecker/about2expire.php');
+$t->data['formTarget'] = SimpleSAML\Module::getModuleURL('expirychecker/about2expire.php');
 $t->data['formData'] = ['StateId' => $stateId];
 $t->data['daysLeft'] = $state['daysLeft'];
 $t->data['dayOrDays'] = (intval($state['daysLeft']) === 1 ? 'day' : 'days');

--- a/www/about2expire.php
+++ b/www/about2expire.php
@@ -34,7 +34,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         $returnTo = sspmod_expirychecker_Utilities::getUrlFromRelayState(
             $state['saml:RelayState']
         );
-        if ( ! empty($returnTo)) {                                 
+        if (! empty($returnTo)) {
             $passwordChangeUrl .= '?returnTo=' . $returnTo;
         }
     }

--- a/www/expired.php
+++ b/www/expired.php
@@ -39,7 +39,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
 $globalConfig = SimpleSAML_Configuration::getInstance();
 
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'expirychecker:expired.php');
-$t->data['formTarget'] = SimpleSAML_Module::getModuleURL('expirychecker/expired.php');
+$t->data['formTarget'] = SimpleSAML\Module::getModuleURL('expirychecker/expired.php');
 $t->data['formData'] = ['StateId' => $stateId];
 $t->data['expiresAtTimestamp'] = $state['expiresAtTimestamp'];
 $t->data['accountName'] = $state['accountName'];

--- a/www/expired.php
+++ b/www/expired.php
@@ -28,7 +28,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         $returnTo = sspmod_expirychecker_Utilities::getUrlFromRelayState(
             $state['saml:RelayState']
         );
-        if ( ! empty($returnTo)) {                                 
+        if (! empty($returnTo)) {
             $passwordChangeUrl .= '?returnTo=' . $returnTo;
         }
     }

--- a/www/expired.php
+++ b/www/expired.php
@@ -45,4 +45,4 @@ $t->data['expiresAtTimestamp'] = $state['expiresAtTimestamp'];
 $t->data['accountName'] = $state['accountName'];
 $t->show();
 
-SimpleSAML_Logger::info('expirychecker - User has been told that their password has expired.');
+SimpleSAML\Logger::info('expirychecker - User has been told that their password has expired.');


### PR DESCRIPTION
This is to resolve any messages along the following lines that this module was triggering:
```
The class or interface 'SimpleSAML_Logger' is now using namespaces, please use 'SimpleSAML\Logger'.
```

Since my IDE is now set up to PSR2-format code on save, there are also some of those changes. If you want to just see the meaningful changes, [click here](https://github.com/silinternational/simplesamlphp-module-expirychecker/pull/23/files/80325ec9c34d64caa2576135acd4f5a446d1d136).